### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A Model Context Protocol (MCP) server that enhances Claude AI's capabilities by 
 > doesn't have subject matter expertise (lack of Python knowledge).  Since it has become rather cost
 > prohibitive, I do not intend to develop or maintain this project further.
 
+<a href="https://glama.ai/mcp/servers/g4vkk4v3w5"><img width="380" height="200" src="https://glama.ai/mcp/servers/g4vkk4v3w5/badge" alt="IaC Memory Server MCP server" /></a>
+
 ## Overview
 
 The IaC Memory MCP Server addresses the challenge of maintaining accurate, version-aware context for IaC components by providing:


### PR DESCRIPTION
This PR adds a badge for the [IaC Memory MCP Server](https://glama.ai/mcp/servers/g4vkk4v3w5) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/g4vkk4v3w5"><img width="380" height="200" src="https://glama.ai/mcp/servers/g4vkk4v3w5/badge" alt="IaC Memory Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.